### PR TITLE
[scattered-collect] perf/miri: improve performance of lookups and fix hazard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,14 +845,14 @@ dependencies = [
 
 [[package]]
 name = "scattered-collect"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "codspeed-divan-compat",
  "ctor 1.0.13",
  "link-section 0.19.3",
  "linktime 0.19.0",
  "linktime-proc-macro 0.2.3",
- "scattered-collect 0.22.1",
+ "scattered-collect 0.22.2",
  "trybuild",
  "wide",
  "xxhash-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ ctor = { path = "ctor", version = "1.0.13", default-features = false }
 dtor = { path = "dtor", version = "1.0.6", default-features = false }
 link-section = { path = "link-section", version = "0.19.3", default-features = false }
 linktime = { path = "linktime", version = "0.19.0", default-features = false }
-scattered-collect = { path = "scattered-collect", version = "0.22.1" }
+scattered-collect = { path = "scattered-collect", version = "0.22.2" }
 
 linktime-proc-macro = { path = "linktime-proc-macro", version = "0.2.3" }

--- a/scattered-collect/CHANGELOG.md
+++ b/scattered-collect/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.2] - 2026-09-10
 
-Recommended patch: performance 
+Recommended patch: major performance
 
 ### Fixed
 
@@ -15,9 +15,7 @@ Recommended patch: performance
   (~2x faster, ahead of std HashMap)
 - Major improvements on x64 (~3x faster on misses, ~30% on hit)
 - Fixed UB risk in initialization
-- Short-circuit hashmap lookups on empty bucket
-- Concurrent first access to a map no longer panics; racing threads now
-  wait for initialization to finish
+- Short-circuit hashmap lookups on empty bucket 
 
 ## [0.22.1] - 2026-08-14
 

--- a/scattered-collect/CHANGELOG.md
+++ b/scattered-collect/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.2] - 2026-09-10
+
+Recommended patch: performance 
+
+### Fixed
+
+- Major performance improvements in lookup on ARM by removing CAS in hot path
+  (~2x faster, ahead of std HashMap)
+- Major improvements on x64 (~3x faster on misses, ~30% on hit)
+- Fixed UB risk in initialization
+- Short-circuit hashmap lookups on empty bucket
+- Concurrent first access to a map no longer panics; racing threads now
+  wait for initialization to finish
+
 ## [0.22.1] - 2026-08-14
 
 ### Fixed

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scattered-collect"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/scattered-collect/benches/map.rs
+++ b/scattered-collect/benches/map.rs
@@ -73,8 +73,8 @@ fn scattered_map_lookup(bencher: Bencher) {
         for (n, key) in [(500, "key0500"), (100, "key0100"), (254, "key0254")] {
             let hash = const_hash!(key);
             let offset = (table.lookup_fn)(&table, hash);
-            let value = offset.map(|offset| &MAP_RECORDS[offset as usize].value);
-            assert_eq!(value, Some(&n));
+            let value = &MAP_RECORDS[offset as usize].value;
+            assert_eq!(value, &n);
         }
     });
 }

--- a/scattered-collect/benches/map.rs
+++ b/scattered-collect/benches/map.rs
@@ -73,7 +73,7 @@ fn scattered_map_lookup(bencher: Bencher) {
         for (n, key) in [(500, "key0500"), (100, "key0100"), (254, "key0254")] {
             let hash = const_hash!(key);
             let offset = (table.lookup_fn)(&table, hash);
-            let value = &MAP_RECORDS[offset as usize].value;
+            let value = &MAP_RECORDS[offset.unwrap() as usize].value;
             assert_eq!(value, &n);
         }
     });

--- a/scattered-collect/benches/map.rs
+++ b/scattered-collect/benches/map.rs
@@ -72,7 +72,7 @@ fn scattered_map_lookup(bencher: Bencher) {
     bencher.bench_local(|| {
         for (n, key) in [(500, "key0500"), (100, "key0100"), (254, "key0254")] {
             let hash = const_hash!(key);
-            let offset = (table.lookup_fn)(&table, hash);
+            let offset = table.lookup(hash);
             let value = &MAP_RECORDS[offset.unwrap() as usize].value;
             assert_eq!(value, &n);
         }

--- a/scattered-collect/src/hash.rs
+++ b/scattered-collect/src/hash.rs
@@ -106,9 +106,12 @@ macro_rules! const_hash {
 
 #[cfg(test)]
 mod tests {
+    use crate::hash::ConstHash;
+
     #[test]
     fn test_const_hash_str() {
         assert_eq!(const_hash!("hello"), 10760762337991515389);
+        assert_eq!(ConstHash::hash("hello"), 10760762337991515389);
     }
 
     #[test]

--- a/scattered-collect/src/hash.rs
+++ b/scattered-collect/src/hash.rs
@@ -21,16 +21,18 @@ macro_rules! const_hash_str {
             impl ConstHash for $ty {
                 type Hasher = StrHasher;
                 const HASHER: Self::Hasher = StrHasher;
+                #[inline(always)]
                 fn hash(&self) -> u64 {
-                    (Self::HASHER).const_hash(self)
+                    xxhash_rust::xxh3::xxh3_64(self.as_bytes())
                 }
             }
 
             impl <'a> ConstHash for &'a $ty {
                 type Hasher = StrHasher;
                 const HASHER: Self::Hasher = StrHasher;
+                #[inline(always)]
                 fn hash(&self) -> u64 {
-                    (Self::HASHER).const_hash(self)
+                    xxhash_rust::xxh3::xxh3_64(self.as_bytes())
                 }
             }
         )*

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
 use crate::map::MapRecord;
 use crate::map::probe::{
-    BUCKET_SIZE, Bucket, LinearProbe, LookupResult, ProbeStrategy, control_byte_from_hash,
-    match_mask, split_hash,
+    BUCKET_SIZE, Bucket, LinearProbe, ProbeStrategy, control_byte_from_hash, match_mask, split_hash,
 };
-use crate::map::table::{BUCKET_STRIDE, MetadataStride, ScatteredMapTable, lookup};
+use crate::map::table::{BUCKET_STRIDE, MetadataStride, ScatteredMapTable};
 
 pub const SAFE_CAPACITY: f32 = 0.70;
 pub const BASE_CAPACITY: usize = 512;
@@ -50,20 +49,16 @@ pub fn initialize_scattered_map<K, V>(
     if n == 0 {
         return ScatteredMapTable {
             metadata: &[],
-            lookup_fn: |_table, _h| LookupResult::not_found(),
             index_bits: 0,
         };
     }
 
-    let (lookup_fn, index_bits): (fn(&ScatteredMapTable, h: u64) -> LookupResult, _);
+    let index_bits;
     if records.len() < 256 {
-        lookup_fn = lookup::<8, LinearProbe>;
         index_bits = 8;
     } else if records.len() < 65536 {
-        lookup_fn = lookup::<16, LinearProbe>;
         index_bits = 16;
     } else {
-        lookup_fn = lookup::<24, LinearProbe>;
         index_bits = 24;
     }
 
@@ -118,7 +113,6 @@ pub fn initialize_scattered_map<K, V>(
 
     ScatteredMapTable {
         metadata,
-        lookup_fn,
         index_bits,
     }
 }

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -53,14 +53,13 @@ pub fn initialize_scattered_map<K, V>(
         };
     }
 
-    let index_bits;
-    if records.len() < 256 {
-        index_bits = 8;
+    let index_bits = if records.len() < 256 {
+        8
     } else if records.len() < 65536 {
-        index_bits = 16;
+        16
     } else {
-        index_bits = 24;
-    }
+        24
+    };
 
     let align = align_of::<MetadataStride>();
     let base = refs.as_mut_ptr() as usize;

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -1,7 +1,4 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
-
-use std::u64;
-
 use crate::map::MapRecord;
 use crate::map::probe::{
     BUCKET_SIZE, Bucket, LinearProbe, ProbeStrategy, control_byte_from_hash, match_mask, split_hash,

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -10,6 +10,11 @@ pub const SAFE_CAPACITY: f32 = 0.70;
 pub const BASE_CAPACITY: usize = 512;
 pub const PER_ITEM_CAPACITY: usize = 14;
 
+const _: () = assert!(
+    BASE_CAPACITY >= 3 * size_of::<MetadataStride>() + align_of::<MetadataStride>(),
+    "BASE_CAPACITY too small for METADATA_STRIDE"
+);
+
 #[allow(unused)]
 pub const fn safe_record_count_for_capacity(capacity: usize) -> usize {
     (capacity * 100 / ((SAFE_CAPACITY * 100.0) as usize)) / MetadataStride::CAPACITY + 2
@@ -25,6 +30,7 @@ pub const fn safe_byte_count_for_capacity(capacity: usize) -> usize {
 pub const fn pack_hash(index_bits: u8, hash: u64, index: usize) -> u64 {
     let hash_mask: u64 = (-1_i64 as u64) << (index_bits as usize);
     let index_mask = !hash_mask;
+    debug_assert!(index as u64 <= index_mask);
     hash & hash_mask | (index as u64) & index_mask
 }
 
@@ -68,7 +74,7 @@ pub fn initialize_scattered_map<K, V>(
         let hash = record.hash;
         let ctrl_byte = control_byte_from_hash(hash);
 
-        let mut probe = LinearProbe::new(num_groups, hash);
+        let mut probe = LinearProbe::new(num_groups * BUCKET_STRIDE, hash);
 
         loop {
             let Some(g) = probe.next() else {
@@ -109,10 +115,7 @@ pub fn initialize_scattered_map<K, V>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        const_hash,
-        map::{probe::split_hash, table::HASH_STRIDE},
-    };
+    use crate::{const_hash, map::probe::split_hash};
 
     #[test]
     fn initialize_table() {
@@ -134,14 +137,14 @@ mod tests {
         for group in table.metadata {
             for (group_offset, bucket) in group.buckets.iter().enumerate() {
                 let ctrl = bucket.as_array();
-                for lane in 0..16 {
+                for lane in 0..BUCKET_SIZE {
                     if ctrl[lane] == 0 {
                         continue;
                     }
                     assert_ne!(ctrl[lane] & 0x80, 0, "occupied slot must have tag bit set");
                     let (hash, offset) = split_hash(
                         table.index_bits,
-                        group.hashes[group_offset * HASH_STRIDE + lane],
+                        group.hashes[group_offset * BUCKET_SIZE + lane],
                     );
                     assert!(offset < 2, "bad row index: {offset}");
                     eprintln!("hash: {hash:x}, offset: {offset}");
@@ -151,6 +154,65 @@ mod tests {
             }
         }
         assert!(seen[0] && seen[1]);
+    }
+
+    #[allow(unsafe_code)]
+    fn round_trip(n: usize, strides: usize) {
+        let mut buffer: Vec<MetadataStride> = (0..strides).map(|_| MetadataStride::ZERO).collect();
+        let refs: &'static mut [u8] = unsafe {
+            core::slice::from_raw_parts_mut(
+                buffer.as_mut_ptr().cast::<u8>(),
+                strides * std::mem::size_of::<MetadataStride>(),
+            )
+        };
+
+        let keys: Vec<String> = (0..n).map(|i| format!("key{i:08}")).collect();
+        let records: Vec<MapRecord<&str, usize>> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, k)| MapRecord::new(k.as_str(), i, crate::hash::ConstHash::hash(&k.as_str())))
+            .collect();
+
+        let table = initialize_scattered_map(&records, refs);
+
+        for (i, key) in keys.iter().enumerate() {
+            let found = table.lookup(crate::hash::ConstHash::hash(&key.as_str()));
+            assert!(found.is_found(), "n={n} strides={strides}: missed {key}");
+            assert_eq!(found.unwrap() as usize, i, "n={n} strides={strides}: {key}");
+        }
+
+        for i in 0..if cfg!(miri) { 50 } else { 1000 } {
+            let key = format!("absent{i:08}");
+            let found = table.lookup(crate::hash::ConstHash::hash(&key.as_str()));
+            if found.is_found() {
+                assert!(
+                    (found.unwrap() as usize) < n,
+                    "n={n} strides={strides}: out-of-range index for {key}"
+                );
+            }
+        }
+    }
+
+    const ROUND_TRIP_SIZES: &[usize] = if cfg!(miri) {
+        &[1, 2, 16, 17, 255, 256, 257]
+    } else {
+        &[
+            1, 2, 15, 16, 17, 255, 256, 257, 1000, 5000, 65535, 65536, 70000,
+        ]
+    };
+
+    #[test]
+    fn lookup_round_trip_safe_capacity() {
+        for &n in ROUND_TRIP_SIZES {
+            round_trip(n, safe_record_count_for_capacity(n));
+        }
+    }
+
+    #[test]
+    fn lookup_round_trip_full_table() {
+        for &n in ROUND_TRIP_SIZES {
+            round_trip(n, n.div_ceil(MetadataStride::CAPACITY));
+        }
     }
 
     // Make sure we always have enough slack space for the metadata.

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
 use crate::map::MapRecord;
 use crate::map::probe::{
-    BUCKET_SIZE, Bucket, LinearProbe, ProbeStrategy, control_byte_from_hash, first_empty_lane,
-    match_mask, split_hash,
+    BUCKET_SIZE, LinearProbe, ProbeStrategy, control_byte_from_hash, first_empty_lane, match_mask,
+    split_hash,
 };
 use crate::map::table::{BUCKET_STRIDE, MetadataStride, ScatteredMapTable};
 

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
 use crate::map::MapRecord;
 use crate::map::probe::{
-    BUCKET_SIZE, Bucket, LinearProbe, ProbeStrategy, control_byte_from_hash, match_mask, split_hash,
+    BUCKET_SIZE, Bucket, LinearProbe, LookupResult, ProbeStrategy, control_byte_from_hash,
+    match_mask, split_hash,
 };
 use crate::map::table::{BUCKET_STRIDE, MetadataStride, ScatteredMapTable, lookup};
 
@@ -49,12 +50,12 @@ pub fn initialize_scattered_map<K, V>(
     if n == 0 {
         return ScatteredMapTable {
             metadata: &[],
-            lookup_fn: |_table, _h| u64::MAX,
+            lookup_fn: |_table, _h| LookupResult::not_found(),
             index_bits: 0,
         };
     }
 
-    let (lookup_fn, index_bits): (fn(&ScatteredMapTable, h: u64) -> u64, _);
+    let (lookup_fn, index_bits): (fn(&ScatteredMapTable, h: u64) -> LookupResult, _);
     if records.len() < 256 {
         lookup_fn = lookup::<8, LinearProbe>;
         index_bits = 8;

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
 use crate::map::MapRecord;
 use crate::map::probe::{
-    BUCKET_SIZE, Bucket, LinearProbe, ProbeStrategy, control_byte_from_hash, match_mask, split_hash,
+    BUCKET_SIZE, Bucket, LinearProbe, ProbeStrategy, control_byte_from_hash, first_empty_lane,
+    match_mask, split_hash,
 };
 use crate::map::table::{BUCKET_STRIDE, MetadataStride, ScatteredMapTable};
 
@@ -25,17 +26,6 @@ pub const fn pack_hash(index_bits: u8, hash: u64, index: usize) -> u64 {
     let hash_mask: u64 = (-1_i64 as u64) << (index_bits as usize);
     let index_mask = !hash_mask;
     hash & hash_mask | (index as u64) & index_mask
-}
-
-/// First lane index in `buckets` whose byte is `0` (empty), using SIMD.
-#[inline]
-pub fn first_empty_lane(buckets: &Bucket) -> Option<usize> {
-    let mask = buckets.simd_eq(Bucket::splat(0)).to_bitmask();
-    if mask == 0 {
-        None
-    } else {
-        Some(mask.trailing_zeros() as usize)
-    }
 }
 
 /// Initialize a scattered map table from a slice of records.

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
 
+use std::u64;
+
 use crate::map::MapRecord;
 use crate::map::probe::{
     BUCKET_SIZE, Bucket, LinearProbe, ProbeStrategy, control_byte_from_hash, match_mask, split_hash,
@@ -50,12 +52,12 @@ pub fn initialize_scattered_map<K, V>(
     if n == 0 {
         return ScatteredMapTable {
             metadata: &[],
-            lookup_fn: |_table, _h| None,
+            lookup_fn: |_table, _h| u64::MAX,
             index_bits: 0,
         };
     }
 
-    let (lookup_fn, index_bits): (fn(&ScatteredMapTable, h: u64) -> Option<u64>, _);
+    let (lookup_fn, index_bits): (fn(&ScatteredMapTable, h: u64) -> u64, _);
     if records.len() < 256 {
         lookup_fn = lookup::<8, LinearProbe>;
         index_bits = 8;

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -104,12 +104,16 @@ impl<K: ConstHash + PartialEq + 'static, V: 'static> ScatteredMap<K, V> {
         let this = self.state;
         let table = this.ensure_initialized();
         let hash = ConstHash::hash(key);
-        let offset = (table.lookup_fn)(table, hash)?;
-        let record = &this.records[offset as usize];
-        if record.key.borrow() == key {
-            Some(&record.value)
-        } else {
+        let offset = (table.lookup_fn)(table, hash);
+        if offset == u64::MAX {
             None
+        } else {
+            let record = &this.records[offset as usize];
+            if record.key.borrow() == key {
+                Some(&record.value)
+            } else {
+                None
+            }
         }
     }
 

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -286,7 +286,7 @@ impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
         }
 
         match self.state.load(Ordering::Acquire) {
-            FINISHED_INITIALIZING => return unsafe { self.table_ref() },
+            FINISHED_INITIALIZING => unsafe { self.table_ref() },
             POISONED => panic!("Initialization of static variable panicked"),
             _ => panic!("Recursive or overlapping initialization of static variable"),
         }

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -104,7 +104,7 @@ impl<K: ConstHash + PartialEq + 'static, V: 'static> ScatteredMap<K, V> {
         let this = self.state;
         let table = this.ensure_initialized();
         let hash = ConstHash::hash(key);
-        let offset = (table.lookup_fn)(table, hash);
+        let offset = table.lookup(hash);
         if offset.is_found() {
             let record = &this.records[offset.unwrap() as usize];
             if record.key.borrow() == key {

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -1,7 +1,7 @@
 //! A swiss-table-style lookup table initialized with link-time data.
 #![doc = concat!("```rust\n", include_str!("../../examples/map.rs"), "\n```\n")]
 
-use link_section::{TypedMutableSection, TypedSection};
+use link_section::{__support::SyncUnsafeCell, TypedMutableSection, TypedSection};
 use std::{
     borrow::Borrow,
     mem::MaybeUninit,
@@ -17,6 +17,11 @@ pub use build::{initialize_scattered_map, safe_byte_count_for_capacity};
 mod build;
 mod probe;
 mod table;
+
+// Table init atomic states
+const UNINITIALIZED: u8 = 0;
+const INITIALIZING: u8 = 1;
+const FINISHED_INITIALIZING: u8 = 2;
 
 /// One gathered map entry.
 ///
@@ -204,7 +209,7 @@ pub struct __ScatteredMapState<K: 'static, V: 'static> {
     state: AtomicU8,
     records: &'static TypedSection<MapRecord<K, V>>,
     refs: &'static TypedMutableSection<u8>,
-    table: ::core::mem::MaybeUninit<ScatteredMapTable>,
+    table: SyncUnsafeCell<MaybeUninit<ScatteredMapTable>>,
 }
 
 impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
@@ -217,7 +222,7 @@ impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
             state: AtomicU8::new(0),
             records,
             refs,
-            table: MaybeUninit::uninit(),
+            table: SyncUnsafeCell::new(MaybeUninit::uninit()),
         }
     }
 
@@ -230,21 +235,43 @@ impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
         self.records.as_slice()
     }
 
+    /// Ensure that the table has been initialized using atomic read (fast),
+    /// then falling back to CAS if that suggests non-initialization.
     #[allow(unsafe_code)]
+    #[inline]
     fn ensure_initialized(&self) -> &ScatteredMapTable {
-        match self
-            .state
-            .compare_exchange(0, 1, Ordering::Relaxed, Ordering::Relaxed)
-        {
+        if self.state.load(Ordering::Acquire) == FINISHED_INITIALIZING {
+            return unsafe { self.table_ref() };
+        }
+        self.initialize_slow()
+    }
+
+    /// Only valid once `state` has been atomically observed as
+    /// `FINISHED_INITIALIZING`.
+    #[allow(unsafe_code)]
+    #[inline]
+    unsafe fn table_ref(&self) -> &ScatteredMapTable {
+        unsafe { &*self.table.get().cast::<ScatteredMapTable>() }
+    }
+
+    #[allow(unsafe_code)]
+    #[cold]
+    fn initialize_slow(&self) -> &ScatteredMapTable {
+        match self.state.compare_exchange(
+            UNINITIALIZED,
+            INITIALIZING,
+            Ordering::Relaxed,
+            Ordering::Acquire,
+        ) {
             Ok(_) => {
                 let table = build::initialize_scattered_map(self.records, unsafe {
                     self.refs.as_mut_slice()
                 });
-                unsafe { ptr::write(self.table.as_ptr() as _, table) };
-                self.state.store(2, Ordering::Relaxed);
-                unsafe { self.table.assume_init_ref() }
+                unsafe { ptr::write(self.table.get().cast::<ScatteredMapTable>(), table) };
+                self.state.store(FINISHED_INITIALIZING, Ordering::Release);
+                unsafe { self.table_ref() }
             }
-            Err(2) => unsafe { self.table.assume_init_ref() },
+            Err(FINISHED_INITIALIZING) => unsafe { self.table_ref() },
             Err(_) => panic!("Recursive or overlapping initialization of static variable"),
         }
     }

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -22,6 +22,15 @@ mod table;
 const UNINITIALIZED: u8 = 0;
 const INITIALIZING: u8 = 1;
 const FINISHED_INITIALIZING: u8 = 2;
+const POISONED: u8 = 3;
+
+struct PoisonOnUnwind<'a>(&'a AtomicU8);
+
+impl Drop for PoisonOnUnwind<'_> {
+    fn drop(&mut self) {
+        self.0.store(POISONED, Ordering::Release);
+    }
+}
 
 /// One gathered map entry.
 ///
@@ -219,7 +228,7 @@ impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
         refs: &'static TypedMutableSection<u8>,
     ) -> Self {
         Self {
-            state: AtomicU8::new(0),
+            state: AtomicU8::new(UNINITIALIZED),
             records,
             refs,
             table: SyncUnsafeCell::new(MaybeUninit::uninit()),
@@ -257,22 +266,29 @@ impl<K: 'static, V: 'static> __ScatteredMapState<K, V> {
     #[allow(unsafe_code)]
     #[cold]
     fn initialize_slow(&self) -> &ScatteredMapTable {
-        match self.state.compare_exchange(
-            UNINITIALIZED,
-            INITIALIZING,
-            Ordering::Relaxed,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => {
-                let table = build::initialize_scattered_map(self.records, unsafe {
-                    self.refs.as_mut_slice()
-                });
-                unsafe { ptr::write(self.table.get().cast::<ScatteredMapTable>(), table) };
-                self.state.store(FINISHED_INITIALIZING, Ordering::Release);
-                unsafe { self.table_ref() }
-            }
-            Err(FINISHED_INITIALIZING) => unsafe { self.table_ref() },
-            Err(_) => panic!("Recursive or overlapping initialization of static variable"),
+        if self
+            .state
+            .compare_exchange(
+                UNINITIALIZED,
+                INITIALIZING,
+                Ordering::Relaxed,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            let guard = PoisonOnUnwind(&self.state);
+            let table =
+                build::initialize_scattered_map(self.records, unsafe { self.refs.as_mut_slice() });
+            unsafe { ptr::write(self.table.get().cast::<ScatteredMapTable>(), table) };
+            std::mem::forget(guard);
+            self.state.store(FINISHED_INITIALIZING, Ordering::Release);
+            return unsafe { self.table_ref() };
+        }
+
+        match self.state.load(Ordering::Acquire) {
+            FINISHED_INITIALIZING => return unsafe { self.table_ref() },
+            POISONED => panic!("Initialization of static variable panicked"),
+            _ => panic!("Recursive or overlapping initialization of static variable"),
         }
     }
 }

--- a/scattered-collect/src/map/mod.rs
+++ b/scattered-collect/src/map/mod.rs
@@ -105,15 +105,15 @@ impl<K: ConstHash + PartialEq + 'static, V: 'static> ScatteredMap<K, V> {
         let table = this.ensure_initialized();
         let hash = ConstHash::hash(key);
         let offset = (table.lookup_fn)(table, hash);
-        if offset == u64::MAX {
-            None
-        } else {
-            let record = &this.records[offset as usize];
+        if offset.is_found() {
+            let record = &this.records[offset.unwrap() as usize];
             if record.key.borrow() == key {
                 Some(&record.value)
             } else {
                 None
             }
+        } else {
+            None
         }
     }
 

--- a/scattered-collect/src/map/probe.rs
+++ b/scattered-collect/src/map/probe.rs
@@ -85,6 +85,11 @@ pub fn match_mask(group: &Bucket, tag: u8) -> u32 {
 }
 
 #[inline]
+pub fn has_empty(group: &Bucket) -> bool {
+    group.simd_lt(Bucket::splat(0x80)).to_bitmask() != 0
+}
+
+#[inline]
 pub fn split_hash(index_bits: u8, hash: u64) -> (u64, usize) {
     let hash_mask: u64 = (-1_i64 as u64) << (index_bits as usize);
     let index_mask = !hash_mask;

--- a/scattered-collect/src/map/probe.rs
+++ b/scattered-collect/src/map/probe.rs
@@ -1,5 +1,4 @@
 #![allow(unreachable_pub)]
-
 pub type Bucket = wide::u8x16;
 
 pub const BUCKET_SIZE: usize = std::mem::size_of::<Bucket>();
@@ -45,6 +44,7 @@ pub struct LinearProbe {
     len: usize,
     remaining: usize,
     pos: usize,
+    stride: usize,
 }
 
 impl ProbeStrategy for LinearProbe {
@@ -55,6 +55,7 @@ impl ProbeStrategy for LinearProbe {
             len,
             remaining: len,
             pos,
+            stride: 1,
         }
     }
 
@@ -64,7 +65,7 @@ impl ProbeStrategy for LinearProbe {
             return None;
         }
         let p = self.pos;
-        self.pos = (self.pos + 1) % self.len;
+        self.pos = (self.pos.wrapping_add(self.stride)) % self.len;
         self.remaining -= 1;
         Some(p)
     }

--- a/scattered-collect/src/map/probe.rs
+++ b/scattered-collect/src/map/probe.rs
@@ -4,6 +4,32 @@ pub type Bucket = wide::u8x16;
 
 pub const BUCKET_SIZE: usize = std::mem::size_of::<Bucket>();
 
+#[repr(C)]
+pub struct LookupResult(u32);
+
+impl LookupResult {
+    #[inline(always)]
+    pub const fn found(at: i32) -> Self {
+        debug_assert!(at > 0);
+        LookupResult(at as u32)
+    }
+
+    #[inline(always)]
+    pub const fn not_found() -> Self {
+        LookupResult(u32::MAX)
+    }
+
+    #[inline(always)]
+    pub const fn is_found(&self) -> bool {
+        (self.0 as i32) >= 0
+    }
+
+    #[inline(always)]
+    pub const fn unwrap(self) -> u32 {
+        self.0
+    }
+}
+
 /// Pluggable probe strategy for the scattered map.
 ///
 /// For [`LinearProbe`], `len` is the number of **groups** (each group is 16 slots). The iterator

--- a/scattered-collect/src/map/probe.rs
+++ b/scattered-collect/src/map/probe.rs
@@ -86,7 +86,7 @@ pub fn match_mask(group: &Bucket, tag: u8) -> u32 {
 
 #[inline]
 pub fn has_empty(group: &Bucket) -> bool {
-    group.simd_lt(Bucket::splat(0x80)).to_bitmask() != 0
+    group.simd_eq(Bucket::splat(0)).to_bitmask() != 0
 }
 
 #[inline]
@@ -94,4 +94,15 @@ pub fn split_hash(index_bits: u8, hash: u64) -> (u64, usize) {
     let hash_mask: u64 = (-1_i64 as u64) << (index_bits as usize);
     let index_mask = !hash_mask;
     (hash & hash_mask, (hash & index_mask) as usize)
+}
+
+/// First lane index in `buckets` whose byte is `0` (empty), using SIMD.
+#[inline]
+pub fn first_empty_lane(buckets: &Bucket) -> Option<usize> {
+    let mask = buckets.simd_eq(Bucket::splat(0)).to_bitmask();
+    if mask == 0 {
+        None
+    } else {
+        Some(mask.trailing_zeros() as usize)
+    }
 }

--- a/scattered-collect/src/map/probe.rs
+++ b/scattered-collect/src/map/probe.rs
@@ -3,7 +3,7 @@ pub type Bucket = wide::u8x16;
 
 pub const BUCKET_SIZE: usize = std::mem::size_of::<Bucket>();
 
-#[repr(C)]
+#[repr(transparent)]
 pub struct LookupResult(u32);
 
 impl LookupResult {
@@ -25,6 +25,7 @@ impl LookupResult {
 
     #[inline(always)]
     pub const fn unwrap(self) -> u32 {
+        debug_assert!(self.is_found());
         self.0
     }
 }

--- a/scattered-collect/src/map/probe.rs
+++ b/scattered-collect/src/map/probe.rs
@@ -10,7 +10,7 @@ pub struct LookupResult(u32);
 impl LookupResult {
     #[inline(always)]
     pub const fn found(at: i32) -> Self {
-        debug_assert!(at > 0);
+        debug_assert!(at >= 0);
         LookupResult(at as u32)
     }
 

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
 
+use std::u64;
+
 use crate::map::probe::{BUCKET_SIZE, Bucket, ProbeStrategy, control_byte_from_hash, match_mask};
 
 // Cache line sizes:
@@ -41,14 +43,15 @@ impl MetadataStride {
 #[doc(hidden)]
 pub struct ScatteredMapTable {
     pub metadata: &'static [MetadataStride],
-    pub lookup_fn: fn(&ScatteredMapTable, h: u64) -> Option<u64>,
+    /// Index, or `u64::MAX` if none
+    pub lookup_fn: fn(&ScatteredMapTable, h: u64) -> u64,
     pub index_bits: u8,
 }
 
 pub fn lookup<const INDEX_BITS: u8, P: ProbeStrategy>(
     table: &ScatteredMapTable,
     h: u64,
-) -> Option<u64> {
+) -> u64 {
     let tag = control_byte_from_hash(h);
     let hash_mask: u64 = (-1_i64 as u64) << (INDEX_BITS as usize);
     let index_mask = !hash_mask;
@@ -64,12 +67,12 @@ pub fn lookup<const INDEX_BITS: u8, P: ProbeStrategy>(
             let lane = bits.trailing_zeros() as usize;
             let h2 = group.hashes[group_offset * BUCKET_SIZE + lane];
             if h2 & hash_mask == masked_hash {
-                return Some(h2 & index_mask);
+                return h2 & index_mask;
             }
             bits &= bits - 1;
         }
     }
-    None
+    u64::MAX
 }
 
 #[cfg(test)]
@@ -99,7 +102,7 @@ mod tests {
 
         let result = lookup::<16, LinearProbe>(&table, HASH);
 
-        assert_eq!(result, Some(15));
+        assert_eq!(result, 15);
     }
 
     /// Find a single record somewhere in the table.
@@ -124,6 +127,6 @@ mod tests {
         };
 
         let result = lookup::<INDEX_BITS, LinearProbe>(&table, HASH);
-        assert_eq!(result, Some(99));
+        assert_eq!(result, 99);
     }
 }

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
 use crate::map::probe::{
-    BUCKET_SIZE, Bucket, LookupResult, ProbeStrategy, control_byte_from_hash, match_mask,
+    BUCKET_SIZE, Bucket, LinearProbe, LookupResult, ProbeStrategy, control_byte_from_hash,
+    match_mask,
 };
 
 // Cache line sizes:
@@ -42,11 +43,23 @@ impl MetadataStride {
 #[doc(hidden)]
 pub struct ScatteredMapTable {
     pub metadata: &'static [MetadataStride],
-    /// Index, or `u64::MAX` if none
-    pub lookup_fn: fn(&ScatteredMapTable, h: u64) -> LookupResult,
     pub index_bits: u8,
 }
 
+impl ScatteredMapTable {
+    #[inline]
+    pub fn lookup(&self, h: u64) -> LookupResult {
+        let offset = match self.index_bits {
+            8 => lookup::<8, LinearProbe>(self, h),
+            16 => lookup::<16, LinearProbe>(self, h),
+            24 => lookup::<24, LinearProbe>(self, h),
+            _ => unreachable!(),
+        };
+        offset
+    }
+}
+
+#[inline]
 pub fn lookup<const INDEX_BITS: u8, P: ProbeStrategy>(
     table: &ScatteredMapTable,
     h: u64,
@@ -96,7 +109,6 @@ mod tests {
 
         let table = ScatteredMapTable {
             metadata: &RECORDS,
-            lookup_fn: lookup::<INDEX_BITS, LinearProbe>,
             index_bits: INDEX_BITS,
         };
 
@@ -122,7 +134,6 @@ mod tests {
 
         let table = ScatteredMapTable {
             metadata: &RECORDS,
-            lookup_fn: lookup::<16, LinearProbe>,
             index_bits: INDEX_BITS,
         };
 

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
-use crate::map::probe::{BUCKET_SIZE, Bucket, ProbeStrategy, control_byte_from_hash, match_mask};
+use crate::map::probe::{
+    BUCKET_SIZE, Bucket, LookupResult, ProbeStrategy, control_byte_from_hash, match_mask,
+};
 
 // Cache line sizes:
 //  - macOS (ARM): 128 bytes
@@ -41,14 +43,14 @@ impl MetadataStride {
 pub struct ScatteredMapTable {
     pub metadata: &'static [MetadataStride],
     /// Index, or `u64::MAX` if none
-    pub lookup_fn: fn(&ScatteredMapTable, h: u64) -> u64,
+    pub lookup_fn: fn(&ScatteredMapTable, h: u64) -> LookupResult,
     pub index_bits: u8,
 }
 
 pub fn lookup<const INDEX_BITS: u8, P: ProbeStrategy>(
     table: &ScatteredMapTable,
     h: u64,
-) -> u64 {
+) -> LookupResult {
     let tag = control_byte_from_hash(h);
     let hash_mask: u64 = (-1_i64 as u64) << (INDEX_BITS as usize);
     let index_mask = !hash_mask;
@@ -64,12 +66,12 @@ pub fn lookup<const INDEX_BITS: u8, P: ProbeStrategy>(
             let lane = bits.trailing_zeros() as usize;
             let h2 = group.hashes[group_offset * BUCKET_SIZE + lane];
             if h2 & hash_mask == masked_hash {
-                return h2 & index_mask;
+                return LookupResult::found((h2 & index_mask) as _);
             }
             bits &= bits - 1;
         }
     }
-    u64::MAX
+    LookupResult::not_found()
 }
 
 #[cfg(test)]
@@ -99,7 +101,7 @@ mod tests {
 
         let result = lookup::<16, LinearProbe>(&table, HASH);
 
-        assert_eq!(result, 15);
+        assert_eq!(result.unwrap(), 15);
     }
 
     /// Find a single record somewhere in the table.
@@ -124,6 +126,6 @@ mod tests {
         };
 
         let result = lookup::<INDEX_BITS, LinearProbe>(&table, HASH);
-        assert_eq!(result, 99);
+        assert_eq!(result.unwrap(), 99);
     }
 }

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -12,34 +12,44 @@ use crate::map::probe::{
 // u64 hash: 8 bytes (16 x 8 = 128)
 // default group: 16 bytes
 
-pub const BUCKET_STRIDE: usize = 1;
-pub const HASH_STRIDE: usize = BUCKET_STRIDE * BUCKET_SIZE;
+/// Slots per [`MetadataStride`]. Tuned per-platform to optimize cache usage.
+pub const METADATA_STRIDE: usize = 16;
+
+pub const BUCKET_STRIDE: usize = METADATA_STRIDE / BUCKET_SIZE;
+pub const HASH_STRIDE: usize = METADATA_STRIDE;
+
+const _: () = assert!(
+    METADATA_STRIDE > 0 && METADATA_STRIDE.is_multiple_of(BUCKET_SIZE),
+    "METADATA_STRIDE must be a non-zero multiple of BUCKET_SIZE"
+);
 
 /// A stride of metadata. Buckets are groups, then associated hashes are
 /// grouped. This is tuned per-platform to optimize cache usage.
 #[repr(C)]
-#[derive(Default)]
 pub struct MetadataStride {
     pub buckets: [Bucket; BUCKET_STRIDE],
     pub hashes: [u64; HASH_STRIDE],
 }
 
+impl Default for MetadataStride {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
 impl MetadataStride {
     pub const ZERO: Self = Self {
-        buckets: [Bucket::splat(0)],
+        buckets: [Bucket::splat(0); BUCKET_STRIDE],
         hashes: [0; HASH_STRIDE],
     };
 
     /// The maximum number of records that can be stored in this metadata stride.
-    pub const CAPACITY: usize = HASH_STRIDE;
+    pub const CAPACITY: usize = METADATA_STRIDE;
 }
 
 /// A pre-built scattered map table. This efficiently maps a u64 to an index.
 /// The index is packed into the low N bits of the u64 and effectively reduces
 /// the hash space.
-///
-/// Since there is a (miniscule) chance of hash collision, a lookup will return
-/// a continuation key to allow for future probing.
 #[doc(hidden)]
 pub struct ScatteredMapTable {
     pub metadata: &'static [MetadataStride],
@@ -50,10 +60,11 @@ impl ScatteredMapTable {
     #[inline]
     pub fn lookup(&self, h: u64) -> LookupResult {
         match self.index_bits {
+            0 => LookupResult::not_found(),
             8 => lookup::<8, LinearProbe>(self, h),
             16 => lookup::<16, LinearProbe>(self, h),
             24 => lookup::<24, LinearProbe>(self, h),
-            _ => LookupResult::not_found(),
+            _ => unreachable!(),
         }
     }
 }
@@ -66,7 +77,7 @@ pub fn lookup<const INDEX_BITS: u8, P: ProbeStrategy>(
     let tag = control_byte_from_hash(h);
     let hash_mask: u64 = (-1_i64 as u64) << (INDEX_BITS as usize);
     let index_mask = !hash_mask;
-    let mut probe = P::new(table.metadata.len(), h);
+    let mut probe = P::new(table.metadata.len() * BUCKET_STRIDE, h);
     let masked_hash = h & hash_mask;
 
     while let Some(g) = probe.next() {
@@ -101,7 +112,11 @@ mod tests {
         const INDEX_BITS: u8 = 16;
         static RECORDS: [MetadataStride; 1] = const {
             let mut records = [MetadataStride::ZERO];
-
+            let mut j = 0;
+            while j < records[0].buckets.len() {
+                records[0].buckets[j] = Bucket::splat(0x80);
+                j += 1;
+            }
             let mut bucket = [0; _];
             bucket[3] = control_byte_from_hash(HASH);
             records[0].buckets[0] = Bucket::new(bucket);

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
 use crate::map::probe::{
     BUCKET_SIZE, Bucket, LinearProbe, LookupResult, ProbeStrategy, control_byte_from_hash,
-    match_mask,
+    has_empty, match_mask,
 };
 
 // Cache line sizes:
@@ -53,7 +53,7 @@ impl ScatteredMapTable {
             8 => lookup::<8, LinearProbe>(self, h),
             16 => lookup::<16, LinearProbe>(self, h),
             24 => lookup::<24, LinearProbe>(self, h),
-            _ => unreachable!(),
+            _ => LookupResult::not_found(),
         }
     }
 }
@@ -82,6 +82,9 @@ pub fn lookup<const INDEX_BITS: u8, P: ProbeStrategy>(
                 return LookupResult::found(idx);
             }
             bits &= bits - 1;
+        }
+        if has_empty(&group.buckets[group_offset]) {
+            return LookupResult::not_found();
         }
     }
     LookupResult::not_found()
@@ -123,7 +126,15 @@ mod tests {
         const INDEX_BITS: u8 = 16;
         static RECORDS: [MetadataStride; 128] = const {
             let mut records = [MetadataStride::ZERO; 128];
-
+            let mut i = 0;
+            while i < records.len() {
+                let mut j = 0;
+                while j < records[i].buckets.len() {
+                    records[i].buckets[j] = Bucket::splat(0x80);
+                    j += 1;
+                }
+                i += 1;
+            }
             let mut bucket = [0; _];
             bucket[7] = control_byte_from_hash(HASH);
             records[99].buckets[0] = Bucket::new(bucket);

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -57,7 +57,8 @@ pub struct ScatteredMapTable {
 }
 
 impl ScatteredMapTable {
-    #[inline]
+    // `inline(always)`: passes ato-inliner threshold otherwise.
+    #[inline(always)]
     pub fn lookup(&self, h: u64) -> LookupResult {
         match self.index_bits {
             0 => LookupResult::not_found(),

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -66,7 +66,8 @@ pub fn lookup<const INDEX_BITS: u8, P: ProbeStrategy>(
             let lane = bits.trailing_zeros() as usize;
             let h2 = group.hashes[group_offset * BUCKET_SIZE + lane];
             if h2 & hash_mask == masked_hash {
-                return LookupResult::found((h2 & index_mask) as _);
+                let idx = (h2 & index_mask) as _;
+                return LookupResult::found(idx);
             }
             bits &= bits - 1;
         }

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -49,13 +49,12 @@ pub struct ScatteredMapTable {
 impl ScatteredMapTable {
     #[inline]
     pub fn lookup(&self, h: u64) -> LookupResult {
-        let offset = match self.index_bits {
+        match self.index_bits {
             8 => lookup::<8, LinearProbe>(self, h),
             16 => lookup::<16, LinearProbe>(self, h),
             24 => lookup::<24, LinearProbe>(self, h),
             _ => unreachable!(),
-        };
-        offset
+        }
     }
 }
 

--- a/scattered-collect/src/map/table.rs
+++ b/scattered-collect/src/map/table.rs
@@ -1,7 +1,4 @@
 #![allow(clippy::modulo_one, unreachable_pub)]
-
-use std::u64;
-
 use crate::map::probe::{BUCKET_SIZE, Bucket, ProbeStrategy, control_byte_from_hash, match_mask};
 
 // Cache line sizes:

--- a/scattered-collect/tests/map_lookup.rs
+++ b/scattered-collect/tests/map_lookup.rs
@@ -1,0 +1,68 @@
+//! Lookup coverage for `ScatteredMap`/`ScatteredSet`.
+
+use scattered_collect::{ScatteredSet, gather, map::ScatteredMap, scatter};
+
+#[gather]
+static FRUIT: ScatteredMap<&'static str, u32>;
+
+#[scatter(FRUIT)]
+static APPLE: (&'static str, u32) = ("apple", 1);
+
+#[scatter(FRUIT)]
+static BANANA: (&'static str, u32) = ("banana", 2);
+
+#[scatter(FRUIT)]
+static CHERRY: (&'static str, u32) = ("cherry", 3);
+
+#[gather]
+static FRUIT_NAMES: ScatteredSet<&'static str>;
+
+#[scatter(FRUIT_NAMES)]
+static APPLE_NAME: &'static str = "apple";
+
+#[scatter(FRUIT_NAMES)]
+static BANANA_NAME: &'static str = "banana";
+
+#[test]
+fn map_get_miss() {
+    assert_eq!(FRUIT.get("durian"), None);
+    assert_eq!(FRUIT.get(""), None);
+    assert_eq!(FRUIT.get("appl"), None);
+    assert!(!FRUIT_NAMES.contains("durian"));
+}
+
+#[test]
+fn map_get_agrees_with_iteration() {
+    for (key, value) in &FRUIT {
+        assert_eq!(FRUIT.get(*key), Some(value));
+    }
+}
+
+#[cfg(miri)]
+#[test]
+fn sections_are_empty_under_miri() {
+    assert_eq!(FRUIT.len(), 0);
+}
+
+#[cfg(not(miri))]
+#[test]
+fn map_get_hit() {
+    assert_eq!(FRUIT.get("apple"), Some(&1));
+    assert_eq!(FRUIT.get("banana"), Some(&2));
+    assert_eq!(FRUIT.get("cherry"), Some(&3));
+}
+
+#[cfg(not(miri))]
+#[test]
+fn map_contains_key() {
+    assert!(FRUIT.contains_key("apple"));
+    assert!(!FRUIT.contains_key("durian"));
+}
+
+#[cfg(not(miri))]
+#[test]
+fn set_contains() {
+    assert!(FRUIT_NAMES.contains("apple"));
+    assert!(FRUIT_NAMES.contains("banana"));
+    assert!(!FRUIT_NAMES.contains("cherry"));
+}


### PR DESCRIPTION
Major rework of scattered maps for perf and ordering hazards:

 - `Option<u64>` in probes unnecessarily destroys register allocation - we can use u32 with MAX as a sentinel instead.
 - Initialize was paying an expensive CAS on ARM for each `get`.
 - Fix potential UB when writing through table pointer
 - Use non-const xx3 hash when not in a const path (perf win)
 - Short circuit lookup on empty bucket