### PR TITLE
[experiment] Borrow sanitizer

### DIFF
--- a/.github/jobs/bsan.sh
+++ b/.github/jobs/bsan.sh
@@ -27,11 +27,20 @@ cargo bsan test
 
 cargo bsan run --example "link-section-const"
 
-# Crates outside the workspace, matching the set miri runs.
+# Crates outside the workspace.
 bsan_crates=(
   tests/ctor/edition-2018
+  tests/ctor/edition-2021
+  tests/ctor/edition-2024
+  tests/ctor/no-default-features
   tests/ctor/priority
+  tests/dtor/link-section
+  tests/dtor/no-default-features
   tests/link_section/basic
+  tests/link_section/copied
+  tests/link_section/interior_mut
+  tests/link_section/mutable
+  tests/link_section/no-default-features
 )
 for dir in "${bsan_crates[@]}"; do
   (cd "$dir" && cargo bsan run)

--- a/.github/jobs/bsan.sh
+++ b/.github/jobs/bsan.sh
@@ -25,7 +25,21 @@ export RUSTDOCFLAGS="-C link-arg=$preinit_dir/preinit.o"
 
 cargo bsan test
 
-cargo bsan run --example "link-section-const"
+bsan_examples=(
+  link-section-const
+  scattered-collect-command-registration
+  scattered-collect-intern-strings
+  scattered-collect-iterable
+  scattered-collect-map
+  scattered-collect-referenced-slice
+  scattered-collect-set
+  scattered-collect-slice
+  scattered-collect-sorted-referenced-slice
+  scattered-collect-sorted-slice
+)
+for example in "${bsan_examples[@]}"; do
+  cargo bsan run --example "$example"
+done
 
 # Crates outside the workspace.
 bsan_crates=(

--- a/.github/jobs/bsan.sh
+++ b/.github/jobs/bsan.sh
@@ -26,7 +26,22 @@ export RUSTDOCFLAGS="-C link-arg=$preinit_dir/preinit.o"
 cargo bsan test
 
 bsan_examples=(
+  ctor-advanced
+  ctor-basic
+  ctor-dynamic
+  ctor-example
+  ctor-priority
+  ctor-statics
+  dtor-example
   link-section-const
+  link-section-dyn
+  link-section-empty
+  link-section-example
+  link-section-movable
+  link-section-movable-no-macro
+  link-section-mut
+  link-section-mut-no-macro
+  link-section-ref
   scattered-collect-command-registration
   scattered-collect-intern-strings
   scattered-collect-iterable

--- a/.github/jobs/bsan.sh
+++ b/.github/jobs/bsan.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# BorrowSanitizer (https://borrowsanitizer.com/). Unlike miri, which interprets
+# MIR, bsan instruments real machine code, so the link-section/ctor tests that
+# miri has to skip do run here.
+#
+# `cargo bsan` picks the host target itself and forwards a second `--target` if
+# we pass one, so none of the commands below specify a target.
+
+# Build the instrumented sysroot up front. It would otherwise happen lazily
+# inside the first command, mixing a libstd build into that command's output.
+cargo bsan setup
+
+cargo bsan test
+
+cargo bsan run --example "link-section-const"
+
+# Crates outside the workspace, matching the set miri runs.
+bsan_crates=(
+  tests/ctor/edition-2018
+  tests/ctor/priority
+  tests/link_section/basic
+)
+for dir in "${bsan_crates[@]}"; do
+  (cd "$dir" && cargo bsan run)
+done

--- a/.github/jobs/bsan.sh
+++ b/.github/jobs/bsan.sh
@@ -12,6 +12,17 @@ set -xeuo pipefail
 # inside the first command, mixing a libstd build into that command's output.
 cargo bsan setup
 
+preinit_dir=$(mktemp -d)
+cc -c -fPIC -x c -o "$preinit_dir/preinit.o" - <<'EOF'
+extern void __bsan_init(void);
+__attribute__((section(".preinit_array"),
+               used)) static void (*bsan_preinit)(void) = __bsan_init;
+EOF
+
+host_triple=$(rustc -vV | sed -n 's/^host: //p')
+export "CARGO_TARGET_$(echo "$host_triple" | tr 'a-z-' 'A-Z_')_RUSTFLAGS=-C link-arg=$preinit_dir/preinit.o"
+export RUSTDOCFLAGS="-C link-arg=$preinit_dir/preinit.o"
+
 cargo bsan test
 
 cargo bsan run --example "link-section-const"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -175,21 +175,70 @@ jobs:
           -D missing-docs
       run: ".github/jobs/${{ matrix.job }}.sh"
 
+  # BorrowSanitizer (https://borrowsanitizer.com/)
+  #
+  # bsan ships only as a container image, rebuilt nightly against the current
+  # rust nightly.
+  bsan:
+    name: linux / bsan (nightly)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/borrowsanitizer/bsan:latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Steps run with HOME=/github/home, but the image installs the `bsan`
+      # toolchain (and sets it as the rustup default) under root's home.
+      - name: Use the image's toolchain
+        run: |
+          ln -s /root/.rustup "$HOME/.rustup"
+          echo "/root/.cargo/bin" >> "$GITHUB_PATH"
+
+      # The sysroot is an instrumented libstd.
+      - name: Compute toolchain cache key
+        id: toolchain
+        run: |
+          key=$( { rustc -vV; cargo bsan --version; } | sha256sum | cut -c1-16 )
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Cache sysroot and Rust files
+        continue-on-error: true # https://github.com/actions/cache/issues/1754
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/bsan
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: bsan-${{ steps.toolchain.outputs.key }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            bsan-${{ steps.toolchain.outputs.key }}-
+
+      - name: Run bsan
+        run: .github/jobs/bsan.sh
+
   success:
     runs-on: ubuntu-slim
-    needs: build
+    needs: [build, bsan]
     if: always()
     steps:
       - name: Report success or fail the workflow
         run: |
           echo "build matrix result: ${BUILD_RESULT}"
+          echo "bsan result: ${BSAN_RESULT}"
           if [ "${BUILD_RESULT}" != success ]; then
             echo "::error::Matrix job failed or did not succeed (result=${BUILD_RESULT})."
+            exit 1
+          fi
+          if [ "${BSAN_RESULT}" != success ]; then
+            echo "::error::BorrowSanitizer job failed or did not succeed (result=${BSAN_RESULT})."
             exit 1
           fi
           echo "Success"
         env:
           BUILD_RESULT: ${{ needs.build.result }}
+          BSAN_RESULT: ${{ needs.bsan.result }}
 
   # Tier-*BSD tests (QEMU)
   #

--- a/ctor/Cargo.toml
+++ b/ctor/Cargo.toml
@@ -26,7 +26,8 @@ proc_macro = ["dep:linktime-proc-macro"]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(linktime_no_fail_on_missing_unsafe)',
     'cfg(linktime_used_linker)',
-    'cfg(linktime_asan)'
+    'cfg(linktime_asan)',
+    'cfg(bsan)'
 ] }
 
 [dependencies]

--- a/ctor/tests/macrotest.rs
+++ b/ctor/tests/macrotest.rs
@@ -1,4 +1,4 @@
-#![cfg(not(miri))]
+#![cfg(not(any(miri, bsan)))]
 #![doc = "Macro expansion, trybuild, and cross-target tests for ctor."]
 
 /*

--- a/dtor/Cargo.toml
+++ b/dtor/Cargo.toml
@@ -42,5 +42,6 @@ name = "dtor"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(linktime_no_fail_on_missing_unsafe)',
     'cfg(linktime_used_linker)',
-    'cfg(linktime_asan)'
+    'cfg(linktime_asan)',
+    'cfg(bsan)'
 ] }

--- a/dtor/tests/macrotest.rs
+++ b/dtor/tests/macrotest.rs
@@ -1,4 +1,4 @@
-#![cfg(not(miri))]
+#![cfg(not(any(miri, bsan)))]
 
 //! To overwrite the Linux expansion tests on macOS, run:
 //!

--- a/link-section/Cargo.toml
+++ b/link-section/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = "3"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(linktime_used_linker)',
     'cfg(linktime_asan)',
+    'cfg(bsan)',
 ] }
 
 [[example]]

--- a/link-section/tests/macrotest.rs
+++ b/link-section/tests/macrotest.rs
@@ -1,4 +1,4 @@
-#![cfg(not(miri))]
+#![cfg(not(any(miri, bsan)))]
 
 /*
 

--- a/scattered-collect/Cargo.toml
+++ b/scattered-collect/Cargo.toml
@@ -79,4 +79,5 @@ path = "benches/collections.rs"
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(linktime_used_linker)',
+    'cfg(bsan)',
 ] }

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -181,7 +181,7 @@ mod tests {
             assert_eq!(found.unwrap() as usize, i, "n={n} strides={strides}: {key}");
         }
 
-        for i in 0..if cfg!(miri) { 50 } else { 1000 } {
+        for i in 0..if cfg!(any(miri, bsan)) { 50 } else { 1000 } {
             let key = format!("absent{i:08}");
             let found = table.lookup(crate::hash::ConstHash::hash(&key.as_str()));
             if found.is_found() {
@@ -193,7 +193,7 @@ mod tests {
         }
     }
 
-    const ROUND_TRIP_SIZES: &[usize] = if cfg!(miri) {
+    const ROUND_TRIP_SIZES: &[usize] = if cfg!(any(miri, bsan)) {
         &[1, 2, 16, 17, 255, 256, 257]
     } else {
         &[

--- a/scattered-collect/src/map/build.rs
+++ b/scattered-collect/src/map/build.rs
@@ -181,7 +181,7 @@ mod tests {
             assert_eq!(found.unwrap() as usize, i, "n={n} strides={strides}: {key}");
         }
 
-        for i in 0..if cfg!(any(miri, bsan)) { 50 } else { 1000 } {
+        for i in 0..if cfg!(miri) { 50 } else { 1000 } {
             let key = format!("absent{i:08}");
             let found = table.lookup(crate::hash::ConstHash::hash(&key.as_str()));
             if found.is_found() {
@@ -193,8 +193,10 @@ mod tests {
         }
     }
 
-    const ROUND_TRIP_SIZES: &[usize] = if cfg!(any(miri, bsan)) {
+    const ROUND_TRIP_SIZES: &[usize] = if cfg!(miri) {
         &[1, 2, 16, 17, 255, 256, 257]
+    } else if cfg!(bsan) {
+        &[1, 2, 15, 16, 17, 255, 256, 257, 1000]
     } else {
         &[
             1, 2, 15, 16, 17, 255, 256, 257, 1000, 5000, 65535, 65536, 70000,

--- a/scattered-collect/tests/trybuild.rs
+++ b/scattered-collect/tests/trybuild.rs
@@ -1,5 +1,5 @@
 //! Compile-fail tests for the `#[scatter]` / `#[gather]` macros.
-#![cfg(not(miri))]
+#![cfg(not(any(miri, bsan)))]
 
 #[test]
 #[cfg(not(linktime_used_linker))]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,3 +13,6 @@ crok-lib = { version = "0.8.3", default-features = false, features = ["fancy-reg
 name = "crok"
 path = "test.rs"
 harness = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bsan)'] }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,13 +1,13 @@
 //! Custom (`harness = false`) test runner for the `.crok` files under this
 //! crate. Every `.crok` file is a test.
 
-// Miri is unsupported.
+// Miri and bsan are unsupported: these tests shell out to cargo.
 fn main() {
-    #[cfg(not(miri))]
+    #[cfg(not(any(miri, bsan)))]
     harness::run();
 }
 
-#[cfg(not(miri))]
+#[cfg(not(any(miri, bsan)))]
 mod harness {
     use std::collections::VecDeque;
     use std::path::{Path, PathBuf};


### PR DESCRIPTION
Implement BorrowSanitizer as a parallel validation to Miri. It covers 100% of the external test suite vs ~10-20% of Miri's coverage as it supports all the link-section code natively.